### PR TITLE
Fix: Cannot read property 'file' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class ServerlessIgnore {
 
   ignoreFiles() {
     try {
-      var config = typeof this.serverless.service.custom !== 'undefined' ? this.serverless.service.custom['ignore'] : {};
+      var config = (this.serverless.service.custom || {})['ignore'] || {};
       var configFound = typeof config.file !== 'undefined'
       var ignoreFilePath = configFound ? config.file : '.slsignore'
       var ignoreFile = fs.readFileSync(ignoreFilePath, 'utf8').toString()


### PR DESCRIPTION
This line of code:
```js
typeof this.serverless.service.custom !== 'undefined' ? this.serverless.service.custom['ignore'] : {};
```
would work only if you don't have any custom variables in your `serverless.yml`, because it assumes that `ignore` exists if `custom` exists, which is not true most of the time, because many of us have other custom variables in their config, but still want to use the `.slsignore` file.

Fixes #2 