### PR TITLE
fix: remove deploy command as it overrides the one from serverless

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,14 +9,6 @@ class ServerlessIgnore {
 
     this.serverless.service.package = this.serverless.service.package || {}
 
-    this.commands = {
-      deploy: {
-        lifecycleEvents: [
-          'package'
-        ]
-      },
-    };
-
     this.hooks = {
       'package:cleanup': this.ignoreFiles.bind(this)
     };


### PR DESCRIPTION
Hi,

I've been running into the problem that when running `serverless deploy` with this plugin, the `deploy` command is overridden and it essentially does nothing.

I removed the piece of code that overrode the command as I think this plugin only needs the hook. Alternatively the `deploy` command can be renamed.

Please let me know if this solution is OK as it's causing my setup to fail.

BR,
Goran